### PR TITLE
Fix logout bug calling nonexistent function

### DIFF
--- a/src/action/logout.js
+++ b/src/action/logout.js
@@ -4,11 +4,11 @@ import { UseLocalStorage } from '../hooks/useLocalStorage';
 import { toast } from 'react-toastify';
 
 export async function logoutAction () {
-const {deletItem} = UseLocalStorage()
+const {deleteItem} = UseLocalStorage()
 //deleteUser
-deletItem({key:'userName'})
-deletItem({key:'budgets'})
-deletItem({key:'expenses'})
+deleteItem({key:'userName'})
+deleteItem({key:'budgets'})
+deleteItem({key:'expenses'})
 toast.success("you've deleted your acount!")
 //redirect
   return redirect('/')


### PR DESCRIPTION
## Summary
- cleanup logout action to use `deleteItem` correctly

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497c3092608321a659f5b3816dcc86